### PR TITLE
Fix line-of-sight computation in Board

### DIFF
--- a/CodeOfKutulu.py
+++ b/CodeOfKutulu.py
@@ -201,28 +201,28 @@ class Board:
         left_walled = False
 
         steps = 0
-        while top_walled and right_walled and bot_walled and left_walled == False:
+        while not (top_walled and right_walled and bot_walled and left_walled):
             steps += 1
             top = (origen[0] + steps, origen[1])
             right = (origen[0], origen[1] + steps)
             bot = (origen[0] - steps, origen[1])
             left = (origen[0], origen[1] - steps)
-            if not top_walled and top in board.walkable:
+            if not top_walled and top in self.walkable:
                 cells.add(top)
             else:
                 top_walled = True
 
-            if not right_walled and right in board.walkable:
+            if not right_walled and right in self.walkable:
                 cells.add(right)
             else:
                 right_walled = True
 
-            if not bot_walled and bot in board.walkable:
+            if not bot_walled and bot in self.walkable:
                 cells.add(bot)
             else:
                 bot_walled = True
 
-            if not left_walled and left in board.walkable:
+            if not left_walled and left in self.walkable:
                 cells.add(left)
             else:
                 left_walled = True


### PR DESCRIPTION
## Summary
- Correct Board.los_cells loop to run until all directions are blocked
- Use instance walkable set instead of global reference

## Testing
- `python -m py_compile CodeOfKutulu.py`
- `python - <<'PY'
import ast, types
from typing import List, Dict, Set, Tuple, Optional
from collections import defaultdict
source=open('CodeOfKutulu.py').read()
module = types.ModuleType('temp')
module.__dict__.update({'List': List, 'Dict': Dict, 'Set': Set, 'Tuple': Tuple, 'Optional': Optional, 'defaultdict': defaultdict})
module_ast = ast.parse(source)
needed=[]
for node in module_ast.body:
    if isinstance(node, ast.ClassDef) and node.name in ('Graph','Board'):
        needed.append(node)
    if isinstance(node, ast.FunctionDef) and node.name=='dijkstra':
        needed.append(node)
exec(compile(ast.Module(body=needed, type_ignores=[]), 'temp', 'exec'), module.__dict__)
lines=[".....",".....","....."]
b=module.Board(lines)
print(sorted(b.los_cells((1,1))))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689fa207acb08325b8fae932ceaa5afa