### PR TITLE
Refactor queen threat calculation

### DIFF
--- a/CodeRoyale.py
+++ b/CodeRoyale.py
@@ -743,12 +743,15 @@ class Units:
     def biggest_threat_to_queen() -> 'Optional[Unit]':
         close_knights = Units.closer(Units.enemyKnights, Units.alliedQueen.pos, 350)
         if close_knights:
-            return close_knights[0]
-        else:
-            return None
-        threats = [knight for knight in close_knights if knight.turns_until_death() > knight.turns_to_reach_opposite_queen()]
-        if len(threats) > 0:
-            Units._stored_biggest_threat = min(threats, key=lambda k: k.threat_level())
+            threats = [
+                knight
+                for knight in close_knights
+                if knight.turns_until_death() > knight.turns_to_reach_opposite_queen()
+            ]
+            if len(threats) > 0:
+                Units._stored_biggest_threat = min(threats, key=lambda k: k.threat_level())
+            else:
+                Units._stored_biggest_threat = None
         else:
             Units._stored_biggest_threat = None
         return Units._stored_biggest_threat


### PR DESCRIPTION
## Summary
- remove unreachable early returns in biggest_threat_to_queen
- compute threats only when knights are nearby

## Testing
- `python -m py_compile CodeRoyale.py`
- `python - <<'PY'
class DummyKnight:
    def __init__(self, t_death, t_reach, threat):
        self._t_death = t_death
        self._t_reach = t_reach
        self._threat = threat
    def turns_until_death(self):
        return self._t_death
    def turns_to_reach_opposite_queen(self):
        return self._t_reach
    def threat_level(self):
        return self._threat

class Units:
    enemyKnights = []
    class alliedQueen:
        pos = [0, 0]
    _stored_biggest_threat = None
    @staticmethod
    def closer(knights, pos, radius):
        return knights

def biggest_threat_to_queen() -> 'object | None':
    close_knights = Units.closer(Units.enemyKnights, Units.alliedQueen.pos, 350)
    if close_knights:
        threats = [
            knight
            for knight in close_knights
            if knight.turns_until_death() > knight.turns_to_reach_opposite_queen()
        ]
        if len(threats) > 0:
            Units._stored_biggest_threat = min(threats, key=lambda k: k.threat_level())
        else:
            Units._stored_biggest_threat = None
    else:
        Units._stored_biggest_threat = None
    return Units._stored_biggest_threat

Units.enemyKnights = []
print('Empty:', biggest_threat_to_queen())
Units.enemyKnights = [DummyKnight(5, 3, 10), DummyKnight(3, 4, 5)]
print('Non-empty:', biggest_threat_to_queen())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689fa2d8243883258fd5900103af2810